### PR TITLE
Fixed some flaky tests that depend on file entries ordering

### DIFF
--- a/BoCode.RedoDB.Tester/RedoDBEngineTester.cs
+++ b/BoCode.RedoDB.Tester/RedoDBEngineTester.cs
@@ -135,12 +135,17 @@ namespace BoCode.RedoDB.Tester
                 RedoDBEngine<ContactsSystem>.GetEngine(contacts3).TakeSnapshot();
             }
 
-            var files = Directory.GetFiles(dataPath).Select(x => new FileInfo(x).Name);
-            files.Count().Should().Be(4);
-            files.ElementAt(0).Should().Be("00000000000000000001.commandlog");
-            files.ElementAt(1).Should().Be("00000000000000000002.commandlog");
-            files.ElementAt(2).Should().Be("00000000000000000003.commandlog");
-            files.ElementAt(3).Should().Be("00000000000000000003.snapshot");
+            var files = Directory.GetFiles(dataPath)
+                .Select(x => new FileInfo(x).Name)
+                .OrderBy(x => x)
+                .ToList();
+            
+            files.Should().HaveCount(4);
+           
+            files[0].Should().Be("00000000000000000001.commandlog");
+            files[1].Should().Be("00000000000000000002.commandlog");
+            files[2].Should().Be("00000000000000000003.commandlog");
+            files[3].Should().Be("00000000000000000003.snapshot");
         }
 
         [Fact(DisplayName = "Starting and stopping (disposing) the engine 2 times causes 2 logs to be created. " +

--- a/BoCode.RedoDB.Tester/RedoDBEngineTester.cs
+++ b/BoCode.RedoDB.Tester/RedoDBEngineTester.cs
@@ -166,11 +166,17 @@ namespace BoCode.RedoDB.Tester
                 contacts2.AddContact(new() { Name = "Name2" });
                 RedoDBEngine<ContactsSystem>.GetEngine(contacts2).TakeSnapshot();
             }
-            var files = Directory.GetFiles(dataPath).Select(x => new FileInfo(x).Name);
-            files.Count().Should().Be(3);
-            files.ElementAt(0).Should().Be("00000000000000000001.commandlog");
-            files.ElementAt(1).Should().Be("00000000000000000002.commandlog");
-            files.ElementAt(2).Should().Be("00000000000000000002.snapshot");
+            
+            var files = Directory.GetFiles(dataPath)
+                .Select(x => new FileInfo(x).Name)
+                .OrderBy(x => x)
+                .ToList();
+
+            files.Should().HaveCount(3);
+            
+            files[0].Should().Be("00000000000000000001.commandlog");
+            files[1].Should().Be("00000000000000000002.commandlog");
+            files[2].Should().Be("00000000000000000002.snapshot");
         }
 
         [Fact(DisplayName = "Recovering from log containing property interceptions.")]

--- a/BoCode.RedoDB.Tester/RedoSubdirectoryAttributeTester.cs
+++ b/BoCode.RedoDB.Tester/RedoSubdirectoryAttributeTester.cs
@@ -48,10 +48,15 @@ namespace BoCode.RedoDB.Tester
             }
 
             //ASSERT
-            var files = Directory.GetFiles(Path.Combine(dataPath, "Subdirectory")).Select(x => new FileInfo(x).Name);
-            files.Count().Should().Be(2);
-            files.ElementAt(0).Should().Be("00000000000000000001.commandlog");
-            files.ElementAt(1).Should().Be("00000000000000000001.snapshot");
+            var files = Directory.GetFiles(Path.Combine(dataPath, "Subdirectory"))
+                .Select(x => new FileInfo(x).Name)
+                .OrderBy(x => x)
+                .ToList();
+
+            files.Should().HaveCount(2);
+            
+            files[0].Should().Be("00000000000000000001.commandlog");
+            files[1].Should().Be("00000000000000000001.snapshot");
         }
     }
 }

--- a/BoCode.RedoDB.Tester/SnapshotManagerTester.cs
+++ b/BoCode.RedoDB.Tester/SnapshotManagerTester.cs
@@ -69,9 +69,14 @@ namespace BoCode.RedoDB.Tester
             snapshotManager.TakeSnapshot();
 
             //ASSERT
-            var files = directoryInfo.GetFiles("*.snapshot");
-            files.Count().Should().Be(2);
-            files.Last().Name.Should().Be("00000000000000000002.snapshot");
+            var files = directoryInfo
+                .GetFiles("*.snapshot")
+                .OrderBy(f => f.FullName)
+                .ToList();
+
+            files.Should().HaveCount(2);
+            
+            files[^1].Name.Should().Be("00000000000000000002.snapshot");
         }
     }
 }


### PR DESCRIPTION
All the tests that use files have their files list ordered before using it